### PR TITLE
Simplify CatchInterrupt()

### DIFF
--- a/internals.go
+++ b/internals.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	// Are we listening for interrupts?
-	monInterrupt bool
+	// Once object to ensure CatchInterrupt is only executed once.
+	catchInterruptOnce sync.Once
 
 	// Store pointers to all of the LockedBuffers.
 	allLockedBuffers      []*LockedBuffer

--- a/memguard.go
+++ b/memguard.go
@@ -36,13 +36,6 @@ type LockedBuffer struct {
 	Destroyed bool
 }
 
-/*
-ExitFunc is a function type that takes no arguments and returns
-no values. It is passed to CatchInterrupt which executes it before
-terminating the application securely.
-*/
-type ExitFunc func()
-
 // New creates a new *LockedBuffer and returns it. The
 // LockedBuffer's state is `ReadWrite`. Length
 // must be greater than zero.
@@ -459,7 +452,7 @@ func Trim(b *LockedBuffer, offset, size int) (*LockedBuffer, error) {
 
 /*
 CatchInterrupt starts a goroutine that monitors for
-interrupt signals. It accepts a function of type ExitFunc
+interrupt signals. It accepts a function of type func()
 and executes that before calling SafeExit(0).
 
 	memguard.CatchInterrupt(func() {
@@ -469,7 +462,7 @@ and executes that before calling SafeExit(0).
 If CatchInterrupt is called multiple times, only the first
 call is executed and all subsequent calls are ignored.
 */
-func CatchInterrupt(f ExitFunc) {
+func CatchInterrupt(f func()) {
 	// Only do this if it hasn't been done before.
 	if !monInterrupt {
 		// We've now done this. Don't do it again.

--- a/memguard.go
+++ b/memguard.go
@@ -464,10 +464,7 @@ call is executed and all subsequent calls are ignored.
 */
 func CatchInterrupt(f func()) {
 	// Only do this if it hasn't been done before.
-	if !monInterrupt {
-		// We've now done this. Don't do it again.
-		monInterrupt = true
-
+	catchInterruptOnce.Do(func() {
 		// Create a channel to listen on.
 		c := make(chan os.Signal, 2)
 
@@ -480,7 +477,7 @@ func CatchInterrupt(f func()) {
 			f()         // Execute user function.
 			SafeExit(0) // Exit securely.
 		}()
-	}
+	})
 }
 
 // SafeExit exits the program with the specified return code,


### PR DESCRIPTION
* Remove type `ExitFunc` and replace with `func()`
* Replace hacky "once" code from `CatchInterrupt` with `sync.Once`.