### PR TITLE
Improvements

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,12 +2,12 @@ package memguard
 
 import "errors"
 
+// ErrDestroyed is returned when a function is called on a destroyed LockedBuffer.
+var ErrDestroyed = errors.New("memguard.ErrDestroyed: buffer is destroyed")
+
 // ErrInvalidLength is returned when a LockedBuffer of smaller than one byte is requested.
 var ErrInvalidLength = errors.New("memguard.ErrInvalidLength: length of buffer must be greater than zero")
 
 // ErrReadOnly is returned when a function that needs to modify a LockedBuffer
 // is given a LockedBuffer that is marked as being read-only.
 var ErrReadOnly = errors.New("memguard.ErrReadOnly: buffer is marked read-only")
-
-// ErrDestroyed is returned when a function is called on a destroyed LockedBuffer.
-var ErrDestroyed = errors.New("memguard.ErrDestroyed: buffer is destroyed")

--- a/memguard.go
+++ b/memguard.go
@@ -408,11 +408,8 @@ func DestroyAll() {
 	destroyAllMutex.Lock()
 	defer destroyAllMutex.Unlock()
 
-	// Get a Mutex lock on allLockedBuffers, and get a copy.
-	allLockedBuffersMutex.Lock()
-	toDestroy := make([]*LockedBuffer, len(allLockedBuffers))
-	copy(toDestroy, allLockedBuffers)
-	allLockedBuffersMutex.Unlock()
+	// Get a copy of allLockedBuffers.
+	toDestroy := LockedBuffers()
 
 	// Call destroy on each LockedBuffer.
 	for _, v := range toDestroy {

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -41,8 +41,8 @@ func TestNewFromBytes(t *testing.T) {
 	c.Destroy()
 }
 
-func TestGenKey(t *testing.T) {
-	b, _ := GenKey(32)
+func TestNewRandom(t *testing.T) {
+	b, _ := NewRandom(32)
 
 	if bytes.Equal(b.Buffer, make([]byte, 32)) {
 		t.Error("was not filled with random data")
@@ -50,7 +50,7 @@ func TestGenKey(t *testing.T) {
 
 	b.Destroy()
 
-	if _, err := GenKey(0); err != ErrInvalidLength {
+	if _, err := NewRandom(0); err != ErrInvalidLength {
 		t.Error("expected ErrInvalidLength")
 	}
 }
@@ -89,12 +89,16 @@ func TestReadOnly(t *testing.T) {
 		t.Error("Unexpected State")
 	}
 
-	b.MarkAsReadOnly()
+	if err := b.MarkAsReadOnly(); err != nil {
+		t.Error("unexpected error")
+	}
 	if !b.ReadOnly {
 		t.Error("Unexpected State")
 	}
 
-	b.MarkAsReadWrite()
+	if err := b.MarkAsReadWrite(); err != nil {
+		t.Error("unexpected error")
+	}
 	if b.ReadOnly {
 		t.Error("Unexpected State")
 	}
@@ -308,6 +312,14 @@ func TestCatchInterrupt(t *testing.T) {
 	CatchInterrupt(func() {
 		return
 	})
+
+	var i int
+	catchInterruptOnce.Do(func() {
+		i++
+	})
+	if i != 0 {
+		t.Error("sync.Once failed")
+	}
 }
 
 func TestWipeBytes(t *testing.T) {
@@ -343,8 +355,8 @@ func TestConcurrent(t *testing.T) {
 	b.Destroy()
 }
 
-func TestDisableCoreDumps(t *testing.T) {
-	DisableCoreDumps()
+func TestDisableUnixCoreDumps(t *testing.T) {
+	DisableUnixCoreDumps()
 }
 
 func TestRoundPage(t *testing.T) {

--- a/memguard_test.go
+++ b/memguard_test.go
@@ -350,6 +350,29 @@ func TestTrim(t *testing.T) {
 	}
 }
 
+func TestLockedBuffers(t *testing.T) {
+	a, _ := New(4, false)
+	b, _ := New(4, false)
+	c, _ := New(4, false)
+
+	actualList := []*LockedBuffer{a, b, c}
+	givenList := LockedBuffers()
+
+	if len(actualList) != len(givenList) {
+		t.Error("actual != given")
+	}
+
+	for i := 0; i < len(actualList); i++ {
+		if actualList[i] != givenList[0] && actualList[i] != givenList[1] && actualList[i] != givenList[2] {
+			t.Error("actual != given")
+		}
+	}
+
+	a.Destroy()
+	b.Destroy()
+	c.Destroy()
+}
+
 func TestCatchInterrupt(t *testing.T) {
 	CatchInterrupt(func() {
 		return


### PR DESCRIPTION
- [x] Improve docs.
- [x] Rename GenKey to NewRandom.
- [x] Only execute permissions functions if permissions are changing.
- [x] Rename DisableCoreDumps to DisableUnixCoreDumps.
- [x] Add tests for Once property of CatchInterrupt.
- [x] Allow New functions to create LockedBuffers with alternative permissions.
- [x] Add function to return pointers to every non-destroyed LockedBuffer.